### PR TITLE
strongbox_fixity.py update

### DIFF
--- a/scripts/strongbox_fixity.py
+++ b/scripts/strongbox_fixity.py
@@ -43,11 +43,16 @@ def diff_manifests(manifest, strongbox_list):
     print('\nStrongbox_fixity - IFIscripts')
     print('Analysing %s\n' % manifest)
     # 
-    error_type  = 0
+    error_type = 0
+    white_list = ['manifest-sha512.txt', 'manifest.md5']
     with open(manifest, 'r', encoding='utf-8') as original_manifest:
         aip_manifest = original_manifest.read().splitlines()
     # A list of items in strongbox, that are different in aip sha512 manifest
     strongbox_check = [item for item in strongbox_list if item not in aip_manifest]
+    # A list of manifest-sha512.txt and manifest.md5 in strongbox, that are exception for diff
+    strongbox_except = list(filter(lambda file: any([item in file for item in white_list]), strongbox_check))
+    # A list of remaning items in the strongbox_check, that are the items need to be diff'ed
+    strongbox_remain = list(set(strongbox_check).difference(set(strongbox_except)))
     new_manifest = []
     # A list of items in the AIP manifest, that are different in the strongbox manifest
     aip_check =  [item for item in aip_manifest if item not in strongbox_list]
@@ -57,10 +62,11 @@ def diff_manifests(manifest, strongbox_list):
         print('ERROR ***************************************The files are not on strongbox!!')
         error_type = 1
     # checks if everything in the strongbox list is in the aip manifest.
-    elif len(strongbox_check) == 0:
+    elif len(strongbox_check) == 2 and len(strongbox_except) == 2 and len(strongbox_remain) == 0:
         print('All files in the strongbox manifest are present in your AIP manifest and the hashes validate')
     else:
         for i in strongbox_check:
+
             print('%s is in the strongbox but NOT in the AIP manifest' % i)
         error_type = 1
     if len(aip_check) == 0:

--- a/scripts/strongbox_fixity.py
+++ b/scripts/strongbox_fixity.py
@@ -56,24 +56,34 @@ def diff_manifests(manifest, strongbox_list):
     new_manifest = []
     # A list of items in the AIP manifest, that are different in the strongbox manifest
     aip_check =  [item for item in aip_manifest if item not in strongbox_list]
-    # check if the files are actually on the strongbox
-    if len(strongbox_list) == 0:
-        print('ERROR ***************************************')
-        print('ERROR ***************************************The files are not on strongbox!!')
-        error_type = 1
-    # checks if everything in the strongbox list is in the aip manifest.
-    elif len(strongbox_check) == 2 and len(strongbox_except) == 2 and len(strongbox_remain) == 0:
-        print('All files in the strongbox manifest are present in your AIP manifest and the hashes validate')
+    # Remove sha512 value
+    for i in aip_check:
+        j = aip_check.index(i)
+        aip_check[j] = i[128:]
+    intsec = list(set(strongbox_remain).intersection(set(aip_check)))
+    # check if the files are stuck in the delayed action
+    if len(intsec) == 0:
+        # check if the files are actually on the strongbox
+        if len(strongbox_list) == 0:
+            print('ERROR ***************************************')
+            print('ERROR ***************************************The files are not on strongbox!!')
+            error_type = 1
+        elif len(strongbox_check) == 2 and len(strongbox_except) == 2 and len(strongbox_remain) == 0:
+            print('All files in the strongbox manifest are present in your AIP manifest and the hashes validate')
+        else:
+            for i in strongbox_remain:
+                print('%s is in the strongbox but NOT in the AIP manifest' % i)
+            error_type = 1
+        # checks if everything in the strongbox list is in the aip manifest.
+        if len(aip_check) == 0 and len(intsec) == 0:
+            print('All files in the AIP manifest are present in your strongbox manifest and the hashes validate')
+        else:
+            for i in aip_check:
+                print('%s is in the AIP manifest but NOT in the Strongbox manifest' % i)
+            error_type = 1
     else:
-        for i in strongbox_check:
-
-            print('%s is in the strongbox but NOT in the AIP manifest' % i)
-        error_type = 1
-    if len(aip_check) == 0:
-        print('All files in the AIP manifest are present in your strongbox manifest and the hashes validate')
-    else:
-        for i in strongbox_check:
-            print('%s is in the AIP manifest but NOT in the Strongbox manifest' % i)
+        for i in intsec:
+            print('%s is moved to strongbox but IS NOT WRITTEN TO TAPES' % i)
         error_type = 1
     print('\nAnalysis complete\n')
     return error_type


### PR DESCRIPTION
**This is a set of update for strongbox.py in order to get a more clear info**
1. split get_checksums() from find_checksums()
get_checksums() contains ififuncs.extract_metadata(csv_file) so that the script won't extract csv each time it walks through an AIP.

2. change alert for both strongbox check and aip check
`%s is in the strongbox but NOT in the AIP manifest`
`%s is in the AIP manifest but NOT in the Strongbox manifest`
could be more straightforward as explanations.

3. add alert summary at the end

4. add exception list of root/md5&sha512 for strongbox_check list
Remove alert for root/md5&sha512 in strongbox alert section.

5. add delayed action alert (moved but not written to tapes)
Add an intersection list to get items in both strongbox check and aip check lists, which alerts when the packages is moved to strongbox but strongbox didn't write them to tapes (in the delayed actions).

The scripts now runs like below:

```
C:\Users\Ingest_1>strongbox_fixity.py -csv G:\Ballymun\Harddrive_AIPs\file_report.csv -i G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes\20230209

Strongbox_fixity - IFIscripts
Analysing G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes\20230209\aaa5771\04b8dbc2-d1d8-45a8-a9cc-4f21e40c2d69_manifest-sha512.txt

All files in the strongbox manifest are present in your AIP manifest and the hashes validate
All files in the AIP manifest are present in your strongbox manifest and the hashes validate

Analysis complete


Strongbox_fixity - IFIscripts
Analysing G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes\20230209\aaa5817\17176e28-08e2-4588-b50d-8ad3c1ee3685_manifest-sha512.txt

  17176e28-08e2-4588-b50d-8ad3c1ee3685/objects/SHOGUN_S001_S001_T028.MOV is moved to strongbox but IS NOT WRITTEN TO TAPES
  17176e28-08e2-4588-b50d-8ad3c1ee3685/objects/SHOGUN_S001_S001_T033.MOV is moved to strongbox but IS NOT WRITTEN TO TAPES
  ......

Analysis complete


Strongbox_fixity - IFIscripts
Analysing G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes\20230209\aaa5856\db741ce1-2d53-40ef-8041-89cc8536dcae_manifest-sha512.txt

  db741ce1-2d53-40ef-8041-89cc8536dcae/objects/POOL_1_S001_S001_T004.MOV is moved to strongbox but IS NOT WRITTEN TO TAPES
  db741ce1-2d53-40ef-8041-89cc8536dcae/objects/POOL_1_S001_S001_T001.MOV is moved to strongbox but IS NOT WRITTEN TO TAPES
  ......

Analysis complete

-----
Strongbox Fixity Summary:
 Above AIP(s) returns exceptions. Check the details above.
 aaa5817
 aaa5856
```
```
C:\Users\Ingest_1>strongbox_fixity.py -csv G:\Ballymun\Harddrive_AIPs\file_report.csv -i G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes

Strongbox_fixity - IFIscripts
Analysing G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes\aaa5714\3ded0f86-cf49-485e-babc-af6ebdb31ef4_manifest-sha512.txt

ERROR ***************************************
ERROR ***************************************The files are not on strongbox!!
  3ded0f86-cf49-485e-babc-af6ebdb31ef4/logs/3ded0f86-cf49-485e-babc-af6ebdb31ef4_sip_log.log is in the AIP manifest but NOT in the Strongbox manifest
  3ded0f86-cf49-485e-babc-af6ebdb31ef4/logs/SHEENA MCCAMBLEY VIDEO_manifest.md5_manifest.md5 is in the AIP manifest but NOT in the Strongbox manifest
  ......

Analysis complete

-----
Strongbox Fixity Summary:
 Above AIP(s) returns exceptions. Check the details above.
 aaa5714
```
```
C:\Users\Ingest_1>strongbox_fixity.py -csv G:\Ballymun\Harddrive_AIPs\file_report.csv -i G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes

Strongbox_fixity - IFIscripts
Analysing G:\Ballymun\Harddrive_AIPs\failed_writting_to_tapes\aaa5773\45ac84b5-2dc9-444c-a6e9-d9900c5ccaa9_manifest-sha512.txt

All files in the strongbox manifest are present in your AIP manifest and the hashes validate
  45ac84b5-2dc9-444c-a6e9-d9900c5ccaa9/objects/test is in the AIP manifest but NOT in the Strongbox manifest

Analysis complete

-----
Strongbox Fixity Summary:
 Above AIP(s) returns exceptions. Check the details above.
 aaa5773
```
This has been tested with all abnormal packages.